### PR TITLE
1019326: Resolved dependabot issues by updating angular version

### DIFF
--- a/Open and Save PDF in AWS S3 using Server-Backend/AngularClient/angular.json
+++ b/Open and Save PDF in AWS S3 using Server-Backend/AngularClient/angular.json
@@ -60,10 +60,10 @@
           "builder": "@angular-devkit/build-angular:dev-server",
           "configurations": {
             "production": {
-              "browserTarget": "my-app:build:production"
+              "buildTarget": "my-app:build:production"
             },
             "development": {
-              "browserTarget": "my-app:build:development"
+              "buildTarget": "my-app:build:development"
             }
           },
           "defaultConfiguration": "development"
@@ -71,7 +71,7 @@
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",
           "options": {
-            "browserTarget": "my-app:build"
+            "buildTarget": "my-app:build"
           }
         },
         "test": {

--- a/Open and Save PDF in AWS S3 using Server-Backend/AngularClient/package.json
+++ b/Open and Save PDF in AWS S3 using Server-Backend/AngularClient/package.json
@@ -10,23 +10,23 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^16.0.0",
-    "@angular/common": "^16.0.0",
-    "@angular/compiler": "^16.0.0",
-    "@angular/core": "^16.0.0",
-    "@angular/forms": "^16.0.0",
-    "@angular/platform-browser": "^16.0.0",
-    "@angular/platform-browser-dynamic": "^16.0.0",
-    "@angular/router": "^16.0.0",
+    "@angular/animations": "^19.0.0",
+    "@angular/common": "^19.0.0",
+    "@angular/compiler": "^19.0.0",
+    "@angular/core": "^19.0.0",
+    "@angular/forms": "^19.0.0",
+    "@angular/platform-browser": "^19.0.0",
+    "@angular/platform-browser-dynamic": "^19.0.0",
+    "@angular/router": "^19.0.0",
     "@syncfusion/ej2-angular-pdfviewer": "^21.2.3",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
-    "zone.js": "~0.13.0"
+    "zone.js": "~0.15.0"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^16.0.0",
-    "@angular/cli": "~16.0.0",
-    "@angular/compiler-cli": "^16.0.0",
+    "@angular-devkit/build-angular": "^19.0.0",
+    "@angular/cli": "~19.0.0",
+    "@angular/compiler-cli": "^19.0.0",
     "@types/jasmine": "~4.3.0",
     "jasmine-core": "~4.6.0",
     "karma": "~6.4.0",
@@ -34,6 +34,6 @@
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.0.0",
-    "typescript": "~5.0.2"
+    "typescript": "~5.6.0"
   }
 }

--- a/Open and Save PDF in AWS S3 using Server-Backend/AngularClient/src/app/app.component.ts
+++ b/Open and Save PDF in AWS S3 using Server-Backend/AngularClient/src/app/app.component.ts
@@ -5,6 +5,7 @@ import { LinkAnnotationService, BookmarkViewService, MagnificationService,
   PrintService, FormDesignerService, FormFieldsService} from '@syncfusion/ej2-angular-pdfviewer';
 
 @Component({
+  standalone: false,
   selector: 'app-root',
   // specifies the template string for the PDF Viewer component
   template: 

--- a/Open and Save PDF in AWS S3 using Standalone/AngularClient/angular.json
+++ b/Open and Save PDF in AWS S3 using Standalone/AngularClient/angular.json
@@ -62,10 +62,10 @@
           "builder": "@angular-devkit/build-angular:dev-server",
           "configurations": {
             "production": {
-              "browserTarget": "opensaveaws:build:production"
+              "buildTarget": "opensaveaws:build:production"
             },
             "development": {
-              "browserTarget": "opensaveaws:build:development"
+              "buildTarget": "opensaveaws:build:development"
             }
           },
           "defaultConfiguration": "development"
@@ -73,7 +73,7 @@
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",
           "options": {
-            "browserTarget": "opensaveaws:build"
+            "buildTarget": "opensaveaws:build"
           }
         },
         "test": {

--- a/Open and Save PDF in AWS S3 using Standalone/AngularClient/package.json
+++ b/Open and Save PDF in AWS S3 using Standalone/AngularClient/package.json
@@ -10,15 +10,16 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^16.0.0",
-    "@angular/common": "^16.0.0",
-    "@angular/compiler": "^16.0.0",
-    "@angular/core": "^16.0.0",
-    "@angular/forms": "^16.0.0",
-    "@angular/platform-browser": "^16.0.0",
-    "@angular/platform-browser-dynamic": "^16.0.0",
-    "@angular/router": "^16.0.0",
+    "@angular/animations": "^19.0.0",
+    "@angular/common": "^19.0.0",
+    "@angular/compiler": "^19.0.0",
+    "@angular/core": "^19.0.0",
+    "@angular/forms": "^19.0.0",
+    "@angular/platform-browser": "^19.0.0",
+    "@angular/platform-browser-dynamic": "^19.0.0",
+    "@angular/router": "^19.0.0",
     "@aws-amplify/ui-angular": "^5.0.16",
+    "@aws-sdk/client-s3": "^3.1024.0",
     "@syncfusion/ej2-angular-pdfviewer": "^26.1.40",
     "aws-amplify": "^6.3.8",
     "aws-sdk": "^2.1654.0",
@@ -28,12 +29,12 @@
     "stream-browserify": "^3.0.0",
     "tslib": "^2.3.0",
     "util": "^0.12.5",
-    "zone.js": "~0.13.0"
+    "zone.js": "~0.15.0"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^16.0.1",
-    "@angular/cli": "~16.0.1",
-    "@angular/compiler-cli": "^16.0.0",
+    "@angular-devkit/build-angular": "^19.0.0",
+    "@angular/cli": "~19.0.0",
+    "@angular/compiler-cli": "^19.0.0",
     "@types/jasmine": "~4.3.0",
     "@types/node": "^20.14.9",
     "jasmine-core": "~4.6.0",
@@ -42,6 +43,6 @@
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.0.0",
-    "typescript": "~5.0.2"
+    "typescript": "~5.6.0"
   }
 }

--- a/Open and Save PDF in AWS S3 using Standalone/AngularClient/src/app/app.component.ts
+++ b/Open and Save PDF in AWS S3 using Standalone/AngularClient/src/app/app.component.ts
@@ -4,15 +4,10 @@ import { LinkAnnotationService, BookmarkViewService,
          NavigationService, TextSearchService, TextSelectionService,
          PrintService, FormDesignerService, FormFieldsService, 
          AnnotationService, PageOrganizerService, PdfViewerComponent, CustomToolbarItemModel } from '@syncfusion/ej2-angular-pdfviewer';
-import * as AWS from 'aws-sdk';
-
-AWS.config.update({
-  region: 'pdate this your region',
-  accessKeyId: 'Update this with your access key id', 
-  secretAccessKey: 'Update this with your secret access key',
-});
+import { PutObjectCommandOutput, S3 } from '@aws-sdk/client-s3';
 
 @Component({
+  standalone: false,
   selector: 'app-root',
   // specifies the template string for the PDF Viewer component
   template: `<div class="content-wrapper">
@@ -53,14 +48,20 @@ export class AppComponent implements OnInit {
     }
   }
 
-  private s3 = new AWS.S3();
+  private s3 = new S3({
+    region: 'update this your region',
+    credentials: {
+      accessKeyId: 'Update this with your access key id',
+      secretAccessKey: 'Update this with your secret access key',
+    }
+  });
 
   loadDocument() {
     const getObjectParams = {
       Bucket: 'Update this with your bucket name',
       Key: 'Update this with your key name',
     };
-    this.s3.getObject(getObjectParams, (err, data) => {
+    this.s3.getObject(getObjectParams, (err: any, data: any) => {
       if (err) {
         console.error('Error fetching document:', err);
       } else {
@@ -91,7 +92,7 @@ export class AppComponent implements OnInit {
           Body: uint8Array,
           ContentType: 'application/pdf',
         };
-        this.s3.putObject(putObjectParams, (err, data) => {
+        this.s3.putObject(putObjectParams, (err: any, data?: PutObjectCommandOutput) => {
           if (err) {
             console.error('Error uploading document:', err);
           } else {


### PR DESCRIPTION
### Bug description
Dependabot flagged an outdated and vulnerable version of angular in package.json.
The existing version (16.0.0) contained security advisories and compatibility warnings. Updating was required to maintain dependency stability and remove security alerts.

### Root cause
The project was using an older Next.js (16.0.0) version that Dependabot identified as vulnerable or outdated. This caused dependency mismatch risks, potential security exposure, and triggered automated alerts. The version was not aligned with the recommended patch level for the framework used.

### Solution description
Updated Next.js to the latest compatible patch version 19.0.0 as recommended by Dependabot.
This resolves the security alert, ensures dependency consistency, and improves build/runtime stability for the React PDF Viewer examples.

The following issues will be resolved by this change:

high - [Angular i18n vulnerable to Cross-Site Scripting](https://github.com/SyncfusionExamples/open-save-pdf-documents-in-aws-s3/security/dependabot/46)
high - [Angular i18n vulnerable to Cross-Site Scripting](https://github.com/SyncfusionExamples/open-save-pdf-documents-in-aws-s3/security/dependabot/45)
high - [Angular has XSS Vulnerability via Unsanitized SVG Script Attributes](https://github.com/SyncfusionExamples/open-save-pdf-documents-in-aws-s3/security/dependabot/42)
high - [Angular has XSS Vulnerability via Unsanitized SVG Script Attributes](https://github.com/SyncfusionExamples/open-save-pdf-documents-in-aws-s3/security/dependabot/41)
high - [Angular has XSS Vulnerability via Unsanitized SVG Script Attributes](https://github.com/SyncfusionExamples/open-save-pdf-documents-in-aws-s3/security/dependabot/40)
high - [Angular has XSS Vulnerability via Unsanitized SVG Script Attributes](https://github.com/SyncfusionExamples/open-save-pdf-documents-in-aws-s3/security/dependabot/39)
low - [JavaScript SDK v2 users should add validation to the region parameter value in or migrate to v3](https://github.com/SyncfusionExamples/open-save-pdf-documents-in-aws-s3/security/dependabot/38)
low - [JavaScript SDK v2 users should add validation to the region parameter value in or migrate to v3](https://github.com/SyncfusionExamples/open-save-pdf-documents-in-aws-s3/security/dependabot/37)
low - [JavaScript SDK v2 users should add validation to the region parameter value in or migrate to v3](https://github.com/SyncfusionExamples/open-save-pdf-documents-in-aws-s3/security/dependabot/36)
low - [JavaScript SDK v2 users should add validation to the region parameter value in or migrate to v3](https://github.com/SyncfusionExamples/open-save-pdf-documents-in-aws-s3/security/dependabot/35)
low - [JavaScript SDK v2 users should add validation to the region parameter value in or migrate to v3](https://github.com/SyncfusionExamples/open-save-pdf-documents-in-aws-s3/security/dependabot/34)
high - [Angular Stored XSS Vulnerability via SVG Animation, SVG URL and MathML Attributes](https://github.com/SyncfusionExamples/open-save-pdf-documents-in-aws-s3/security/dependabot/33)
high - [Angular Stored XSS Vulnerability via SVG Animation, SVG URL and MathML Attributes](https://github.com/SyncfusionExamples/open-save-pdf-documents-in-aws-s3/security/dependabot/32)
high - [Angular is Vulnerable to XSRF Token Leakage via Protocol-Relative URLs in Angular HTTP Client](https://github.com/SyncfusionExamples/open-save-pdf-documents-in-aws-s3/security/dependabot/31)
high - [Angular is Vulnerable to XSRF Token Leakage via Protocol-Relative URLs in Angular HTTP Client](https://github.com/SyncfusionExamples/open-save-pdf-documents-in-aws-s3/security/dependabot/30)